### PR TITLE
Handle no arguments in python3

### DIFF
--- a/s3mothball/commands.py
+++ b/s3mothball/commands.py
@@ -105,4 +105,8 @@ def main():
     create_parser.set_defaults(func=extract_command)
 
     args = parser.parse_args()
-    args.func(args, parser)
+    try:
+        args.func(args, parser)
+    except AttributeError:
+        parser.print_help()
+        parser.exit()


### PR DESCRIPTION
Running bare `s3mothball` in Python 3 produces `AttributeError: 'Namespace' object has no attribute 'func'`, apparently a bug in argparse: https://bugs.python.org/issue16308

See also https://stackoverflow.com/questions/48648036/python-argparse-args-has-no-attribute-func